### PR TITLE
Set callback gas limit default in client

### DIFF
--- a/client/src/axiom/axiom.ts
+++ b/client/src/axiom/axiom.ts
@@ -10,6 +10,7 @@ import { convertChainIdToViemChain, convertInputSchemaToJsonString } from "./uti
 import { TransactionReceipt, createPublicClient, createWalletClient, http, zeroAddress, zeroHash } from "viem";
 import { privateKeyToAccount } from 'viem/accounts'
 import { AxiomV2Callback } from "@axiom-crypto/core";
+import { ClientConstants } from "../constants";
 
 export class Axiom<T> {
   protected config: AxiomV2ClientConfig<T>;
@@ -69,6 +70,7 @@ export class Axiom<T> {
 
     const options: AxiomV2ClientOptions = {
       ...this.options,
+      callbackGasLimit: this.options?.callbackGasLimit ?? ClientConstants.CALLBACK_GAS_LIMIT,
       refundee: this.options?.refundee ?? caller,
     }
 

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
 export const ClientConstants = Object.freeze({
   MIN_MAX_FEE_PER_GAS: 5000000000n,
-  MAX_MAX_FEE_PER_GAS: 50000000000n,
+  CALLBACK_GAS_LIMIT: 100000,
 })


### PR DESCRIPTION
- Sets callback gas limit default in client
- sdk-core also sets default limit but we can change that later.