### PR TITLE
Circuitrunner `input` to `inputs`

### DIFF
--- a/circuit/js/src/circuitRunner.ts
+++ b/circuit/js/src/circuitRunner.ts
@@ -138,7 +138,7 @@ export function AxiomCircuitRunner(halo2Wasm: Halo2Wasm, halo2LibWasm: Halo2LibW
     let functionInputs = getInputFunctionSignature(inputs);
     let parsedInputs = parseDataInputs(inputs);
 
-    let fn = eval(`let {${halo2LibFns.join(", ")}} = halo2Lib; let {${axiomDataFns.join(", ")}} = axiomData; (async function(input) { ${code} })`);
+    let fn = eval(`let {${halo2LibFns.join(", ")}} = halo2Lib; let {${axiomDataFns.join(", ")}} = axiomData; (async function(inputs) { ${code} })`);
     await fn(parsedInputs);
 
     const { numUserInstances } = padInstances();


### PR DESCRIPTION
- Update AxiomCircuitRunner `input` to `inputs` for consistency
- AxiomREPL change here as well: https://github.com/axiom-crypto/axiom-repl/blob/feat/browser_typescript/utils/circuit.ts#L56