### PR TITLE
Remove inputSchema passed into constructor

### DIFF
--- a/client/src/axiom/axiom.ts
+++ b/client/src/axiom/axiom.ts
@@ -21,7 +21,6 @@ export class Axiom<T> {
 
   constructor(config: AxiomV2ClientConfig<T>) {
     this.config = config;
-    const inputSchema = convertInputSchemaToJsonString(config.inputSchema);
     this.compiledCircuit = config.compiledCircuit;
     this.callback = {
       target: config.callback.target,
@@ -31,7 +30,7 @@ export class Axiom<T> {
     this.axiomCircuit = new AxiomCircuit({
       f: config.circuit,
       provider: this.config.provider,
-      inputSchema,
+      inputSchema: config.compiledCircuit.inputSchema,
       chainId: this.config.chainId,
     });
   }

--- a/client/src/axiom/types.ts
+++ b/client/src/axiom/types.ts
@@ -13,7 +13,6 @@ export type CircuitInputType = typeof solidityInputTypes[number];
 export interface AxiomV2ClientConfig<T> {
   circuit: (inputs: T) => Promise<void>;
   compiledCircuit: AxiomV2CompiledCircuit;
-  inputSchema: {[arg: string]: CircuitInputType};
   chainId: string;
   provider: string;
   privateKey?: string;


### PR DESCRIPTION
- Uses inputSchema from compiledCircuit instead of needing to specify an inputSchema explicitly in the constructor