### PR TITLE
[chore] `feeData` calculation refactor

### DIFF
--- a/client/src/axiom/utils.ts
+++ b/client/src/axiom/utils.ts
@@ -86,11 +86,16 @@ export async function getMaxFeePerGas(axiom: AxiomSdkCore, overrides?: AxiomV2Cl
       functionName: "minMaxFeePerGas",
       args: [],
     }) as bigint;
+    const sdkMinMaxFeePerGas = getChainDefaults(chainId).minMaxFeePerGasWei;
     if (contractMinMaxFeePerGas === 0n) {
-      contractMinMaxFeePerGas = getChainDefaults(chainId).minMaxFeePerGasWei;
+      contractMinMaxFeePerGas = sdkMinMaxFeePerGas;
     }
     if (providerMaxFeePerGas > contractMinMaxFeePerGas) {
       return providerMaxFeePerGas.toString();
+    }
+    if (contractMinMaxFeePerGas < sdkMinMaxFeePerGas) {
+      console.log(`Network gas price below threshold. Using SDK-defined minimum minMaxFeePerGas of ${sdkMinMaxFeePerGas.toString()}`);
+      return sdkMinMaxFeePerGas.toString();
     }
     console.log(`Network gas price below threshold. Using contract-defined minimum minMaxFeePerGas of ${contractMinMaxFeePerGas.toString()}`);
     return contractMinMaxFeePerGas.toString();

--- a/client/src/axiom/utils.ts
+++ b/client/src/axiom/utils.ts
@@ -89,9 +89,14 @@ export async function getMaxFeePerGas(axiom: AxiomSdkCore, overrides?: AxiomV2Cl
 
     const sdkMinMaxFeePerGas = getChainDefaults(chainId).minMaxFeePerGasWei;
     contractMinMaxFeePerGas = contractMinMaxFeePerGas === 0n ? sdkMinMaxFeePerGas : contractMinMaxFeePerGas;
-    const maxFeePerGas = BigInt(contractMinMaxFeePerGas) > providerMaxFeePerGas ? 
-                         (BigInt(contractMinMaxFeePerGas) > sdkMinMaxFeePerGas ? contractMinMaxFeePerGas : sdkMinMaxFeePerGas) : 
-                         (providerMaxFeePerGas > sdkMinMaxFeePerGas ? providerMaxFeePerGas : sdkMinMaxFeePerGas);
+    
+    let maxFeePerGas = contractMinMaxFeePerGas;
+    if (providerMaxFeePerGas > maxFeePerGas) {
+      maxFeePerGas = providerMaxFeePerGas;
+    }
+    if (sdkMinMaxFeePerGas > maxFeePerGas) {
+      maxFeePerGas = sdkMinMaxFeePerGas;
+    }
     
     if (maxFeePerGas === contractMinMaxFeePerGas) {
       console.log(`Network gas price below threshold. Using contract-defined minMaxFeePerGas: ${maxFeePerGas.toString()}`);

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -3,6 +3,8 @@ import { ChainDefaults } from "./types";
 export const ClientConstants = Object.freeze({
   AXIOM_PROOF_CALLDATA_LEN: 2875, // bytes
   AXIOM_PROOF_CALLDATA_BYTES: "0x" + "11".repeat(2875),
+  L1_FEE_NUMERATOR: 120n, // (1.2x multiplier)
+  L1_FEE_DENOMINATOR: 100n,
 })
 
 export const MainnetDefaults: Readonly<ChainDefaults> = Object.freeze({

--- a/client/src/lib/paymentCalc.ts
+++ b/client/src/lib/paymentCalc.ts
@@ -7,6 +7,13 @@ import { getChainDefaults, isArbitrumChain, isMainnetChain, isOpStackChain, isSc
 import { publicActionsL2 } from 'viem/op-stack';
 import { readContractValueBigInt } from "./viem";
 
+/**
+ * Calculate the payment amount (in wei) for axiom query.
+ * @param chainId The chain ID that we are using
+ * @param publicClient The viem PublicClient instance
+ * @param feeData Fee data calculated from `calculateFeeDataExtended` function
+ * @returns Payment amount in wei
+ */
 export async function calculatePayment(
   chainId: string,
   publicClient: PublicClient,
@@ -39,6 +46,13 @@ export async function calculatePayment(
   }
 }
 
+/**
+ * Calculate the fee data for axiom query.
+ * @param chainId The chain ID that we are using
+ * @param publicClient The viem PublicClient instance
+ * @param options The AxiomV2 client options object
+ * @returns AxiomV2FeeDataExtended struct
+ */
 export async function calculateFeeDataExtended(
   chainId: string,
   publicClient: PublicClient,
@@ -133,6 +147,7 @@ export async function getProjectedL2CallbackCost(
       "getL1Fee",
       [ClientConstants.AXIOM_PROOF_CALLDATA_BYTES],
     );
+    // 1.2x mutltiplier for L1 fee value to ensure the query is fulfilled
     return maxFeePerGas * (callbackGasLimit + proofVerificationGas) + 
       (l1Fee * ClientConstants.L1_FEE_NUMERATOR / ClientConstants.L1_FEE_DENOMINATOR);
   } else if (isArbitrumChain(chainId)) {

--- a/client/src/lib/paymentCalc.ts
+++ b/client/src/lib/paymentCalc.ts
@@ -74,11 +74,11 @@ export async function calculateFeeDataExtended(
   );
 
   let overrideAxiomQueryFee = BigInt(options.overrideAxiomQueryFee ?? "0");
-  if (axiomQueryFee > overrideAxiomQueryFee) {
-    overrideAxiomQueryFee = axiomQueryFee;
-  }
 
   if (isMainnetChain(chainId)) { 
+    if (overrideAxiomQueryFee !== 0n && axiomQueryFee > overrideAxiomQueryFee) {
+      overrideAxiomQueryFee = axiomQueryFee;
+    } 
     return {
       maxFeePerGas: maxFeePerGas.toString(),
       callbackGasLimit: Number(callbackGasLimit),
@@ -91,9 +91,12 @@ export async function calculateFeeDataExtended(
 
     // overrideAxiomQueryFeeL2 = AXIOM_QUERY_FEE + projectedCallbackCost - maxFeePerGas * (callbackGasLimit + proofVerificationGas)
     const overrideAxiomQueryFeeL2 = axiomQueryFee + projectedCallbackCost - maxFeePerGas * (callbackGasLimit + proofVerificationGas);
-    if (overrideAxiomQueryFeeL2 > overrideAxiomQueryFee) {
-      overrideAxiomQueryFee = overrideAxiomQueryFeeL2;
-    }
+    
+    // overrideAxiomQueryFee = max(overrideAxiomQueryFeeL2, AXIOM_QUERY_FEE)
+    const largerAxiomQueryFee = overrideAxiomQueryFeeL2 > axiomQueryFee ? overrideAxiomQueryFeeL2 : axiomQueryFee;
+
+    // overrideAxiomQueryFee = max(overrideAxiomQueryFee, larger)
+    overrideAxiomQueryFee = overrideAxiomQueryFee > largerAxiomQueryFee ? overrideAxiomQueryFee : largerAxiomQueryFee;
     
     return {
       maxFeePerGas: maxFeePerGas.toString(),

--- a/client/src/lib/paymentCalc.ts
+++ b/client/src/lib/paymentCalc.ts
@@ -90,14 +90,16 @@ export async function calculateFeeDataExtended(
       proofVerificationGas,
     };
   } else if (isOpStackChain(chainId) || isArbitrumChain(chainId) || isScrollChain(chainId)) {
+    const defaultAxiomQueryFee = getChainDefaults(chainId).axiomQueryFeeWei;
+
     // Get the projected callback cost
     const projectedCallbackCost = await getProjectedL2CallbackCost(chainId, publicClient, maxFeePerGas, callbackGasLimit, proofVerificationGas);
 
     // overrideAxiomQueryFeeL2 = AXIOM_QUERY_FEE + projectedCallbackCost - maxFeePerGas * (callbackGasLimit + proofVerificationGas)
-    const overrideAxiomQueryFeeL2 = axiomQueryFee + projectedCallbackCost - maxFeePerGas * (callbackGasLimit + proofVerificationGas);
+    const overrideAxiomQueryFeeL2 = defaultAxiomQueryFee + projectedCallbackCost - maxFeePerGas * (callbackGasLimit + proofVerificationGas);
     
-    // overrideAxiomQueryFee = max(overrideAxiomQueryFeeL2, overrideAxiomQueryFee AXIOM_QUERY_FEE)
-    const largerAxiomQueryFee = overrideAxiomQueryFeeL2 > axiomQueryFee ? overrideAxiomQueryFeeL2 : axiomQueryFee;
+    // overrideAxiomQueryFee = max(overrideAxiomQueryFeeL2, overrideAxiomQueryFee, AXIOM_QUERY_FEE)
+    const largerAxiomQueryFee = overrideAxiomQueryFeeL2 > axiomQueryFee ? overrideAxiomQueryFeeL2 : defaultAxiomQueryFee;
     overrideAxiomQueryFee = overrideAxiomQueryFee > largerAxiomQueryFee ? overrideAxiomQueryFee : largerAxiomQueryFee;
     
     return {

--- a/client/src/sendQuery.ts
+++ b/client/src/sendQuery.ts
@@ -117,7 +117,7 @@ export const buildSendQuery = async (input: {
       address: axiomQueryAddress as `0x${string}`,
       abi: abi,
       functionName: "sendQueryWithIpfsData",
-      value: BigInt(payment),
+      value: payment,
       args: [
         queryHash,
         ipfsHash,

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -43,6 +43,10 @@ export interface AxiomV2ClientOptions extends AxiomV2QueryOptions {
   overrides?: AxiomV2ClientOverrides;
 }
 
+export interface AxiomV2FeeDataExtended extends AxiomV2FeeData {
+  proofVerificationGas: bigint;
+}
+
 export interface AxiomV2SendQueryArgs {
   address: string;
   abi: any;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -44,6 +44,7 @@ export interface AxiomV2ClientOptions extends AxiomV2QueryOptions {
 }
 
 export interface AxiomV2FeeDataExtended extends AxiomV2FeeData {
+  axiomQueryFee: bigint;
   proofVerificationGas: bigint;
 }
 

--- a/client/test/unit/lib/paymentCalc/base.test.ts
+++ b/client/test/unit/lib/paymentCalc/base.test.ts
@@ -193,29 +193,26 @@ describe("PaymentCalc: Base", () => {
     const callbackGasLimit = getChainDefaults(CHAIN_ID).callbackGasLimit;
     const proofVerificationGas = getChainDefaults(CHAIN_ID).proofVerificationGas;
 
-    const testFn = async () => {
-      const axiom = new Axiom({
-        circuit,
-        compiledCircuit,
-        chainId: CHAIN_ID,
-        provider: process.env[`PROVIDER_URI_${CHAIN_ID}`] as string,
-        privateKey: process.env.PRIVATE_KEY_ANVIL as string,
-        callback: {
-          target: "0x4A4e2D8f3fBb3525aD61db7Fc843c9bf097c362e",
-        },
-        options: {
-          maxFeePerGas: maxFeePerGas.toString(),
-          overrideAxiomQueryFee: "5000000000",
-        },
-      });
-      await axiom.init();
-      await axiom.prove(inputs);
-      const args = axiom.getSendQueryArgs();
-      
-      const queryCost = calculateQueryCost(basefee, baseFeeScalar, blobBaseFee, blobBaseFeeScalar, maxFeePerGas, callbackGasLimit, proofVerificationGas);
-    };
-    await expect(testFn()).rejects.toThrow();
-    // let percentDiff = percentDiffX100(queryCost, BigInt(args?.value ?? 0));
-    // expect(percentDiff).toBeLessThan(100n); // 1%
+    const axiom = new Axiom({
+      circuit,
+      compiledCircuit,
+      chainId: CHAIN_ID,
+      provider: process.env[`PROVIDER_URI_${CHAIN_ID}`] as string,
+      privateKey: process.env.PRIVATE_KEY_ANVIL as string,
+      callback: {
+        target: "0x4A4e2D8f3fBb3525aD61db7Fc843c9bf097c362e",
+      },
+      options: {
+        maxFeePerGas: maxFeePerGas.toString(),
+        overrideAxiomQueryFee: "500000", // overrideAxiomQueryFee will get overridden with default if it's too low
+      },
+    });
+    await axiom.init();
+    await axiom.prove(inputs);
+    const args = axiom.getSendQueryArgs();
+    
+    const queryCost = calculateQueryCost(basefee, baseFeeScalar, blobBaseFee, blobBaseFeeScalar, maxFeePerGas, callbackGasLimit, proofVerificationGas);
+    let percentDiff = percentDiffX100(queryCost, BigInt(args?.value ?? 0));
+    expect(percentDiff).toBeLessThan(100n); // 1%
   }, 20000);
 });

--- a/client/test/unit/lib/paymentCalc/base.test.ts
+++ b/client/test/unit/lib/paymentCalc/base.test.ts
@@ -30,7 +30,8 @@ describe("PaymentCalc: Base", () => {
   ) => {
     return maxFeePerGas * (callbackGasLimit + proofVerificationGas) + 
       BigInt(ClientConstants.AXIOM_PROOF_CALLDATA_LEN) * 
-      (16n * baseFeeScalar * basefee + blobBaseFeeScalar * blobBaseFee) / BigInt(1e6);
+      (16n * baseFeeScalar * basefee + blobBaseFeeScalar * blobBaseFee)  * 
+      BigInt(ClientConstants.L1_FEE_NUMERATOR) / BigInt(ClientConstants.L1_FEE_DENOMINATOR) / BigInt(1e6);
   }
 
   const calculateQueryCost = (


### PR DESCRIPTION
- Splits `feeData` and `payment` calculations into separate functions and puts it back into the built query

Test before:
```
axiomQueryFee:         3000000000000000
overrideAxiomQueryFee: 3057272684379098
projectedCallbackCost: 577272684379098
maxFeePerGas:          1000000000
proofVerificationGas:  420000
callbackGasLimit:      100000
Payment:               3577272684379098
Minimum Payment:       3577272684379098
```

Test after (note that projectedCallbackCost varies based on the L1 fee from the oracle):
```
axiomQueryFee:         3000000000000000
overrideAxiomQueryFee: 3297672609747220
projectedCallbackCost: 817672609747220
maxFeePerGas           1000000000
callbackGasLimit       100000
proofVerificationGas   420000
payment                3817672609747220
minimumPayment         3817672609747220
```