### PR TITLE
[feat] harness integration tests

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiom-crypto/harness",
-  "version": "2.1.0-rc.2",
+  "version": "2.1.0-rc.3",
   "author": "Intrinsic Technologies",
   "license": "MIT",
   "description": "Circuit harness for axiom-client",

--- a/harness/src/cli/index.ts
+++ b/harness/src/cli/index.ts
@@ -49,6 +49,8 @@ harnessCli
   .argument("<circuit>", "path to the typescript circuit file")
   .argument("<compiled circuit>", "path to the compiled circuit json file")
   .argument("<inputs path>", "path to the inputs json file")
+  .option("-t, --target-chain-id <chain id>", "(crosschain) target chain id")
+  .option("-tr, --target-rpc-url <https url>", "(crosschain) target chain JSON-RPC provider URL (https)")
   .action(handleProve);
 
 harnessCli
@@ -59,6 +61,8 @@ harnessCli
   .argument("<circuit>", "path to the typescript circuit file")
   .argument("<compiled circuit>", "path to the compiled circuit json file")
   .argument("<inputs path>", "path to the inputs json file")
+  .option("-t, --target-chain-id <chain id>", "(crosschain) target chain id")
+  .option("-tr, --target-rpc-url <https url>", "(crosschain) target chain JSON-RPC provider URL (https)")
   .action(handleProveSendQuery);
 
 harnessCli
@@ -71,6 +75,7 @@ harnessCli
   .option("-ci, --circuit-inputs-path <path>", "Path to circuit inputs (default: <chainDataPath>/<chainId>)")
   .option("-f, --function <fnName>", "Function name (default: circuit)", "circuit")
   .option("--send", "Send query after proving")
+  .option("-tr, --target-rpc-url <https url>", "(crosschain) target chain JSON-RPC provider URL (https)")
   .action(run);
 
 harnessCli.parseAsync(process.argv);

--- a/harness/test/integration/start.test.ts
+++ b/harness/test/integration/start.test.ts
@@ -68,7 +68,7 @@ describe("Integration tests", () => {
       */
 
       // Run a test via standard `run` method
-      const receipt = await run({
+      const [axiom, receipt] = await run({
         circuit: circuitPath,
         rpcUrl,
         data,
@@ -91,12 +91,12 @@ describe("Integration tests", () => {
   });
 
   test(`Custom capacity (256)`, async () => {
-    const receipt = await run({
+    const [axiom, receipt] = await run({
       circuit: "./test/integration/circuits/computeQuery/simpleWithCapacity.circuit.ts",
       rpcUrl,
       data,
       send: true,
-      options: { 
+      options: {
         capacity: {
           maxOutputs: 256,
           maxSubqueries: 256,

--- a/harness/test/integration/start.test.ts
+++ b/harness/test/integration/start.test.ts
@@ -74,6 +74,7 @@ describe("Integration tests", () => {
         data,
         send: true,
       })
+      expect(axiom.getSendQueryArgs !== undefined).toBe(true);
       expect(receipt.status).toEqual("success");
     });
   }
@@ -103,6 +104,7 @@ describe("Integration tests", () => {
         },
       },
     });
+    expect(axiom.getSendQueryArgs !== undefined).toBe(true);
     expect(receipt.status).toEqual("success");
   });
 


### PR DESCRIPTION
- Support cross-chain queries in the harness package.
- Modified send query test functions to return the axiom object. With this the caller can access the queryId.

Part of INT-1540